### PR TITLE
Fix caller stack

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ const path = require("path")
 const qs = require("qs")
 const yaml = require("js-yaml")
 const duration = require("iso8601-duration")
+const callsites = require("callsites")
+
 let singleValue = null
 
 const getNodeEnv = () => process.env.NODE_ENV || "development"
@@ -170,9 +172,7 @@ function expandKeys(obj) {
 
 function loadModule(fname) {
   if (!fname.startsWith("/")) {
-    const caller = (new Error).stack.split("\n")[3]
-      .replace(/^.*?\(/, "").replace(/:\d+:\d+\)$/, "")
-    const base = path.dirname(caller)
+    const base = path.dirname(callsites()[2].getFileName())
     fname = path.join(base, fname)
   }
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "typescript": "^2.4.1"
   },
   "dependencies": {
+    "callsites": "^2.0.0",
     "iso8601-duration": "^1.0.6",
     "js-yaml": "^3.10.0",
     "qs": "^6.5.0",


### PR DESCRIPTION
Ao usar o rewire, o stack de chamada fica diferente, dando erro na regexp na hora de identificar qual o arquivo base.

Usando require:
`     at Object.<anonymous> (/home/LAB2W/raul.baldner/Projetos/b2wads/b2ads_billing/services/conversion-service.js:20:16)`

Usando rewire:
`   '    at /home/LAB2W/raul.baldner/Projetos/b2wads/b2ads_billing/services/conversion-service.js:20:14',`

Com essa PR, usamos uma lib especializada em buscar os CallSites para pegar o nome do arquivo.