### PR TITLE
feat(types): Adiciona Generics para aprimorar o linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Env-o-Loader
+# @b2wads/env-o-loader
 
-[b2wads]: http://www.b2wadvertising.com/
+[b2wads]: http://www.b2wads.com/
 [iso8601]: https://en.wikipedia.org/wiki/ISO_8601
 [license]: https://opensource.org/licenses/BSD-3-Clause
 [json]: http://json.org/
@@ -42,13 +42,13 @@ Let’s take the following JSON settings file:
 }
 ```
 
-Env-o-Loader will select the environment according to the `NODE_ENV` envvar
+`@b2wads/env-o-loader` will select the environment according to the `NODE_ENV` envvar
 content, defaults to `development`.
 
-- If `NODE_ENV` is `test`, Env-o-Loader returns `"test environment"`;
-- If `NODE_ENV` is `production`, Env-o-Loader returns the content of the
+- If `NODE_ENV` is `test`, `@b2wads/env-o-loader` returns `"test environment"`;
+- If `NODE_ENV` is `production`, `@b2wads/env-o-loader` returns the content of the
   `MY_VAR` envvar;
-- If `NODE_ENV` is something else, Env-o-Loader returns `"some default value"`.
+- If `NODE_ENV` is something else, `@b2wads/env-o-loader` returns `"some default value"`.
 
 You also can supply the environment you want as second parameter:
 
@@ -75,7 +75,7 @@ For example:
 }
 ```
 
-Under development environment, Env-o-Loader returns the following object:
+Under development environment, `@b2wads/env-o-loader` returns the following object:
 
 ```javascript
 { x: 3, y: 4, z: 5 }
@@ -136,7 +136,7 @@ And can be compound with unnested one:
 
 ### Data from envvar
 
-Using the `env:` prefix, Env-o-Loader loads the content from an envvar.
+Using the `env:` prefix, `@b2wads/env-o-loader` loads the content from an envvar.
 
 To load objects from envvar, use querystring format:
 
@@ -159,7 +159,7 @@ env SETTINGS="v[x]=3&v[y]=4"
 
 ### Other types
 
-If you must load settings from JSON or envvar, Env-o-Loader supports more types
+If you must load settings from JSON or envvar, `@b2wads/env-o-loader` supports more types
 than those formats, serialised as string.
 
 - Date: use [ISO 8601][iso8601]: `2010-10-10` for October 10, 2010.
@@ -188,7 +188,7 @@ To force string, you must prefix the value with `raw:`:
 
 ### Loading files
 
-Env-o-Loader can load files by its names. The supported types are [JSON][json]
+`@b2wads/env-o-loader` can load files by its names. The supported types are [JSON][json]
 and [YAML][yaml].
 
 The JSON file string **must** ends with `.json`, and the YAML file string

--- a/README.md
+++ b/README.md
@@ -10,15 +10,20 @@ This is a helper to make easier loading enviroment-oriented settings.
 
 ## Genesis
 
-This code was born inside [B2WAds][b2wads] code base, and it made sense to
+This code was born inside B2WADS code base, and it made sense to
 release this as [open source](./COPYING).
+
+## Install
+```sh
+npm install @b2wads/env-o-loader
+```
 
 ## Use
 
 Simply import the module and call it as a function:
 
 ```javascript
-const loader = require("env-o-loader")
+const loader = require("@b2wads/env-o-loader")
 const settings = loader(require("config/my-app"))
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,6 @@
-declare namespace envLoader {
-  interface Config {
-    defaults: any
-    [other: string]: any
-  }
-}
-
-declare function envLoader(
-  config: envLoader.Config | string, nodeEnv?: string
-): any
+declare function envLoader<T>(
+  config: { defaults: T } | string, nodeEnv?: string
+): T
 
 export = envLoader
 export as namespace envLoader

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b2wads/env-o-loader",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "config loader with envvar support",
   "main": "index.js",
   "types": "index.d.ts",
@@ -20,10 +20,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:b2wads/env-o-loader.git"
+    "url": "git@github.com:b2wads/b2wads-env-o-loader.git"
   },
   "bugs": {
-    "url": "https://github.com/b2wads/env-o-loader/issues"
+    "url": "https://github.com/b2wads/b2wads-env-o-loader/issues"
   },
   "license": "BSD-3-Clause",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b2wads/env-o-loader",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "config loader with envvar support",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@bitbucket.org:b2wads/env-o-loader.git"
+    "url": "git@github.com:b2wads/env-o-loader.git"
   },
   "bugs": {
     "url": "https://github.com/b2wads/env-o-loader/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "env-o-loader",
-  "version": "1.0.6",
+  "name": "@b2wads/env-o-loader",
+  "version": "1.0.0",
   "description": "config loader with envvar support",
   "main": "index.js",
   "types": "index.d.ts",
@@ -15,16 +15,15 @@
     "test": "npm run lint && npm run build && mocha --reporter dot"
   },
   "author": {
-    "name": "ℜodrigo ℭacilhας",
-    "email": "<batalema@cacilhas.info>",
-    "url": "http://cacilhas.info/kodumaro"
+    "name": "B2WADS",
+    "email": "<dev@b2wads.com>"
   },
   "repository": {
     "type": "git",
-    "url": "git@bitbucket.org:cacilhas/env-o-loader.git"
+    "url": "git@bitbucket.org:b2wads/env-o-loader.git"
   },
   "bugs": {
-    "url": "https://github.com/cacilhas/env-o-loader/issues"
+    "url": "https://github.com/b2wads/env-o-loader/issues"
   },
   "license": "BSD-3-Clause",
   "devDependencies": {


### PR DESCRIPTION
#### Descrição

Atualmente, o `env-o-loader` permite que uma configuração seja informada como um objeto Javascript, seguindo os mesmos padrões do schema de um arquivo `.yaml` ou `.json`, ficando:

```js
const config = envLoader({
    defaults: {
        name: 'env:NAME',
        age: 13
   }
})
```

... porém, o linter não reconhece os campos passados para o construtor `envLoader` e temos que trabalhar com um objeto desconhecido.

![env-loader-without-types](https://user-images.githubusercontent.com/20517508/76245265-543a4c80-621a-11ea-9f68-1bfb225238e3.gif)

#### Solução

A alteração feita, modifica o arquivo de tipos do projeto, sem quebrar compatibiliade com o que já foi criado, permitindo que ao informar uma configuração como objeto Javascript, o linter reconheça os campos que estão dentro de `defaults` e faça o auto-complete:

![env-loader-with-types](https://user-images.githubusercontent.com/20517508/76244845-9c0ca400-6219-11ea-8494-8f863cf71357.gif)